### PR TITLE
chore(docs): better example in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,9 @@ Add the plugin to your Webpack configuration:
 
   resolve: {
     plugins: [new BowerResolvePlugin()],
-    modules: [
-        'bower_components'
-    ],
-    descriptionFiles: ['bower.json', 'package.json'],
-    mainFields: ['main', 'browser']
+    modules: ['bower_components', 'node_modules'],
+    descriptionFiles: ['.bower.json', 'package.json'],
+    mainFields: ['browser', 'main']
   },
 ```
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Add the plugin to your Webpack configuration:
   resolve: {
     plugins: [new BowerResolvePlugin()],
     modules: ['bower_components', 'node_modules'],
-    descriptionFiles: ['.bower.json', 'package.json'],
+    descriptionFiles: ['bower.json', 'package.json'],
     mainFields: ['browser', 'main']
   },
 ```


### PR DESCRIPTION
1. Without `node_modules` lots of requires will fail (assuming user is using npm for some or most of the modules). 
2. There are npm modules that don't ignore and include `bower.json` file, so the loader would use the bower.json incorrectly for certain npm modules. 
3. Give priority to `browser` field before `main`.