### PR TITLE
Need to allow for enhanced-resolve v4 as webpack v4 uses that version of the module

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {},
   "peerDependencies": {
-    "enhanced-resolve": "^3.1.0",
+    "enhanced-resolve": ">= 3.1.0",
     "webpack": ">= 2.2.0"
   }
 }


### PR DESCRIPTION
The code in index.js already uses the interface that enhanced-resolve v4 exposes, we just forgot to update the peer-dep semver-range to accept v4 of enhanced-resolve.